### PR TITLE
Check code formatting on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
       - run: |
           npm install
       - run: |
+          npm run format-check
+      - run: |
           npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest


### PR DESCRIPTION
`npm run all` formats the code, but it doesn't fail the build if the
formatting doesn't follow the configured style.